### PR TITLE
Gracefully handle exception thrown by JSON.parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,12 @@ function GetRequest(options, cb) {
       if (err) {
         cb(err);
       } else {
-        cb(null, JSON.parse(body));
+        try {
+          var data = JSON.parse(body);
+          cb(null, data); 
+        } catch (err) {
+          cb(err)
+        }
       }
     }
   });
@@ -157,6 +162,12 @@ function PostRequest(options, cb) {
         cb('non 200 statusCode: ' + res.statusCode + ', ' + res.body);
       } else {
         cb(null, JSON.parse(body));
+        try {
+          var data = JSON.parse(body);
+          cb(null, data); 
+        } catch (err) {
+          cb(err)
+        }
       }
     }
   });

--- a/index.js
+++ b/index.js
@@ -160,7 +160,6 @@ function PostRequest(options, cb) {
       } else if (res.statusCode / 100 != 2) {
         cb('non 200 statusCode: ' + res.statusCode + ', ' + res.body);
       } else {
-        cb(null, JSON.parse(body));
         try {
           cb(null, JSON.parse(body));
         } catch (err) {

--- a/index.js
+++ b/index.js
@@ -143,8 +143,7 @@ function GetRequest(options, cb) {
         cb(err);
       } else {
         try {
-          var data = JSON.parse(body);
-          cb(null, data); 
+          cb(null, JSON.parse(body)); 
         } catch (err) {
           cb(err)
         }
@@ -163,8 +162,7 @@ function PostRequest(options, cb) {
       } else {
         cb(null, JSON.parse(body));
         try {
-          var data = JSON.parse(body);
-          cb(null, data); 
+          cb(null, JSON.parse(body));
         } catch (err) {
           cb(err)
         }


### PR DESCRIPTION
Ran into this issue when calling summary() with improper token and/or account id.  Unfortunately the API's response is not valid JSON. I believe this is a bug on LendingClub's side. This will gracefully work around this issue.
